### PR TITLE
CK's-Microsoft-FilterList.txt

### DIFF
--- a/Corporations/Microsoft/CK's-Microsoft-FilterList.txt
+++ b/Corporations/Microsoft/CK's-Microsoft-FilterList.txt
@@ -40,7 +40,6 @@
 ||betaoneservices.com^
 ||bing-int.com^
 ||bing.com^
-||bing.net:443^
 ||bing.net^
 ||binginternal.com^
 ||brktx.com^


### PR DESCRIPTION
||bing.net:443^' has been made redundant by '||bing.net^