### PR TITLE
CK's-Pinterest-FilterList.txt

### DIFF
--- a/Corporations/Pinterest/CK's-Pinterest-FilterList.txt
+++ b/Corporations/Pinterest/CK's-Pinterest-FilterList.txt
@@ -17,10 +17,8 @@
 ||detectportal.firefox.com^
 ||experiments.mozilla.org^
 ||fhr.cdn.mozilla.net^
-||incoming.telemetry.mozilla.org^
 ||onyx_tiles.stage.mozaws.net^
 ||search.services.mozilla.com^
-||shavar.services.mozilla.com^
 ||shavar.services.mozilla.com^
 ||tbpl.mozilla.org^
 ||telemetry-experiment.cdn.mozilla.net^


### PR DESCRIPTION
    '||incoming.telemetry.mozilla.org^' has been made redundant by '||telemetry.mozilla.org^'
    '||shavar.services.mozilla.com^' has been made redundant by '||shavar.services.mozilla.com^'