### PR TITLE
Add Dauntless telemetry domain

### DIFF
--- a/HOSTS/CK's-Game-HOSTS-FilterList.txt
+++ b/HOSTS/CK's-Game-HOSTS-FilterList.txt
@@ -2899,6 +2899,10 @@ Cossacks III + Config
 #0.0.0.0 api.paradoxplaza.com
 #0.0.0.0 service.paradoxplaza.com
 
+# Phoenix Labs
+# Dauntless
+0.0.0.0 telemetry.steelyard.ca
+
 # Parallax Labs
 # Despoiler
 0.0.0.0 datarouter.ol.epicgames.com


### PR DESCRIPTION
I've added [Dauntless](https://playdauntless.com/) telemetry domain that is contacted as soon as the launcher is opened.

![](https://linx.li/selif/vke1t8sh.png)